### PR TITLE
Working tiledb2 java bindings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,5 @@
+# de-nix
+
+Nix Derivations to simplify setting up development environments that require compiled libraries.
+
+For help with the build phases of a derivation, see https://nixos.org/manual/nixpkgs/stable/.

--- a/tiledb2-java.nix
+++ b/tiledb2-java.nix
@@ -1,0 +1,39 @@
+with (import <nixpkgs> {});
+
+stdenv.mkDerivation rec {
+  pname = "tiledb2_java";
+
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "TileDB-Inc";
+    repo = "TileDB-Java";
+    rev = version;
+    sha256 = "01kda42fhwsf6mbz5zfwd7csg1r1jxbdadp1wavwi29k5g7hh2ml";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DTILEDB_S3=ON"
+    "-DTILEDB_GIT_TAG=2.0.7"
+  ];
+
+  enableParallelBuilding = true;
+
+  tiledb2 = import(./tiledb2.nix);
+
+  buildInputs = [
+    jdk11
+    tiledb2
+  ];
+
+  installTargets = [ "tiledb_jni" ];
+
+  postInstall = ''
+    cp tiledb_jni/libtiledbjni.so $out
+  '';
+
+}


### PR DESCRIPTION
An example shell.nix might look like
```
with (import <nixpkgs> {});

mkShell rec {
  name = "de-app";

  tiledb2_java = import ../de-nix/tiledb2-java.nix;

  buildInputs = [
    tiledb2_java
  ];

  shellHook = ''
    export JVM_OPTS="$JVM_OPTS -Djava.library.path=${tiledb2_java}"
  '';

}
```